### PR TITLE
Feature/page guard

### DIFF
--- a/src/DefaultRouter.tsx
+++ b/src/DefaultRouter.tsx
@@ -16,6 +16,7 @@ import NoticeEditor from './components/Notice/NoticeEditor';
 import ReportComment from './components/Report/ReportComment';
 import NoticeModifyEditor from './components/Notice/NoticeModifyEditor';
 import Comment from './components/MyPage/Comment/Comment';
+import PrivateRoute from './components/PrivateRoute';
 
 const adminPages = {
   base: 'admin',
@@ -37,43 +38,44 @@ const mypagePages = {
 function Router() {
   return (
     <Routes>
-      <Route path={'/'} element={<DashBoardPage />} />
       <Route path={'/access'} element={<LandingPage />} />
       <Route path={'/google/callback'} element={<LoginProcessPage />} />
-      <Route path="board">
-        <Route path="q&a" element={<QNABoardPage />} />
-        <Route path="tip" element={<TipBoardPage />} />
-      </Route>
-      <Route path="post">
-        <Route path="view" element={<PostViewPage />} />
-        <Route path="write" element={<PostWritePage />} />
-        <Route path="update" element={<PostUpdatePage />} />
-      </Route>
-      <Route path="admin" element={<SidebarLayout links={adminPages} />}>
-        <Route index element={<Navigate replace to="report/post" />} />
-        <Route path="report" element={<Admin.Post />}>
-          <Route index element={<Navigate replace to="post" />} />
-          <Route path="post" element={<ReportPost />} />
-          <Route path="comment" element={<ReportComment />} />
+      <Route element={<PrivateRoute />}>
+        <Route path={'/'} element={<DashBoardPage />} />
+        <Route path="board">
+          <Route path="q&a" element={<QNABoardPage />} />
+          <Route path="tip" element={<TipBoardPage />} />
         </Route>
-        <Route path="notice" element={<Admin.Notice />} />
-        <Route path="notice/write" element={<NoticeEditor />} />
-        <Route
-          path="notice/modify/:notificationId"
-          element={<NoticeModifyEditor />}
-        />
-      </Route>
-      <Route path="mypage" element={<SidebarLayout links={mypagePages} />}>
-        <Route index element={<Navigate replace to="profile" />} />
-        <Route path="profile" element={<MyPage.Profile />} />
-        <Route path="history" element={<MyPage.Post />}>
-          <Route index element={<Navigate replace to="post" />} />
-          <Route path="post" element={<Post />} />
-          <Route path="comment" element={<Comment />} />
+        <Route path="post">
+          <Route path="view" element={<PostViewPage />} />
+          <Route path="write" element={<PostWritePage />} />
+          <Route path="update" element={<PostUpdatePage />} />
         </Route>
-        <Route path="badge" element={<MyPage.Badge />} />
+        <Route path="admin" element={<SidebarLayout links={adminPages} />}>
+          <Route index element={<Navigate replace to="report/post" />} />
+          <Route path="report" element={<Admin.Post />}>
+            <Route index element={<Navigate replace to="post" />} />
+            <Route path="post" element={<ReportPost />} />
+            <Route path="comment" element={<ReportComment />} />
+          </Route>
+          <Route path="notice" element={<Admin.Notice />} />
+          <Route path="notice/write" element={<NoticeEditor />} />
+          <Route
+            path="notice/modify/:notificationId"
+            element={<NoticeModifyEditor />}
+          />
+        </Route>
+        <Route path="mypage" element={<SidebarLayout links={mypagePages} />}>
+          <Route index element={<Navigate replace to="profile" />} />
+          <Route path="profile" element={<MyPage.Profile />} />
+          <Route path="history" element={<MyPage.Post />}>
+            <Route index element={<Navigate replace to="post" />} />
+            <Route path="post" element={<Post />} />
+            <Route path="comment" element={<Comment />} />
+          </Route>
+          <Route path="badge" element={<MyPage.Badge />} />
+        </Route>
       </Route>
-      <Route path="commenttest/:postId" element={<CommentTest />} />
     </Routes>
   );
 }

--- a/src/apis/authApi.ts
+++ b/src/apis/authApi.ts
@@ -25,6 +25,11 @@ export const refreshAccessTokenRequest = () =>
 export const successionUserRequest = (memberId: string | number) =>
   privateRequest.delete(`member/${memberId}`);
 
+export const logoffRequest = () =>
+  axios
+    .get('/oauth/deleteCookie')
+    .catch((e) => alert('로그아웃에 실패했습니다. 다시 시도해주세요'));
+
 /** 2글자 이상 20글자 미만 */
 // 닉네임 업데이트 API
 export const updateMemberNicknameRequest = (memberName: string) =>

--- a/src/components/Badge/BadgeFactory.tsx
+++ b/src/components/Badge/BadgeFactory.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Rounded from '../RoundedImage/RoundedImage';
 import CommentBadge from './CommentBadge';
 import { LikeBadge, WriteBadge } from '.';
 import LikeBadge2 from './LikeBadge';
@@ -8,7 +7,7 @@ type badgeType = 'comment' | 'like' | 'post';
 
 type BadgeFactoryProps = {
   type: badgeType;
-  level: 1 | 2 | 3 | 4 | 5;
+  level: number;
 };
 
 const MAX_LEVEL = 5;
@@ -19,22 +18,19 @@ const badgeInfo = {
   comment: {
     name: '프로 답변러',
     target: 'comment',
-    description: (lv: 1 | 2 | 3 | 4 | 5) =>
-      `답변 작성 갯수가 ${10 * lv}개를 돌파했어요`,
+    description: (lv: number) => `답변 작성 갯수가 ${10 * lv}개를 돌파했어요`,
     component: CommentBadge,
   },
   like: {
     name: '추천 사냥꾼',
     target: 'post',
-    description: (lv: 1 | 2 | 3 | 4 | 5) =>
-      `추천받은 갯수가 ${10 * lv}개를 돌파했어요`,
+    description: (lv: number) => `추천받은 갯수가 ${10 * lv}개를 돌파했어요`,
     component: LikeBadge,
   },
   post: {
     name: '추천 사냥꾼',
     target: 'like',
-    description: (lv: 1 | 2 | 3 | 4 | 5) =>
-      `좋아요 갯수가 ${10 * lv}개를 돌파했어요`,
+    description: (lv: number) => `좋아요 갯수가 ${10 * lv}개를 돌파했어요`,
     component: LikeBadge,
   },
 };

--- a/src/components/Header/re/User/UserBlock.tsx
+++ b/src/components/Header/re/User/UserBlock.tsx
@@ -1,14 +1,19 @@
-import {useNavigate} from "react-router-dom";
+import {Link, useNavigate} from "react-router-dom";
 import React, {ChangeEvent, useEffect, useRef, useState} from "react";
-import {FiBell} from "react-icons/fi";
-import {useInfiniteQuery} from "react-query";
+import {FaBell} from "react-icons/fa";
+import {FiLogOut} from "react-icons/fi";
+import Rounded from "../../../RoundedImage/RoundedImage";
+import {useInfiniteQuery, useQueryClient} from "react-query";
+import useGetMember from "../../../../hooks/useGetMember";
+import { logoffRequest } from "../../../../apis/authApi";
 import {getOldAlarm} from "./test";
 import {AlarmType} from "../../../../types/Alarm";
-import {FaBell} from "react-icons/fa";
 
 
 export default function HeaderUserBlock(){
     const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const {isLoading,data} = useGetMember()
     const [state, setState] = useState({
         alarm: false,
     })
@@ -110,10 +115,23 @@ export default function HeaderUserBlock(){
                     }
                 </ul>
             )}
-            <a
-                href={'/mypage/profile'}
+                    <label
+          className={'relative cursor-pointer'}
+          onClick={() =>
+            logoffRequest().then(() => {
+              queryClient.resetQueries('user');
+              navigate('/access');
+            })
+          }
+        >
+          <FiLogOut size={24} />
+        </label>
+        <Link
+                to={'/mypage/profile'}
                 className={'w-[45px] h-[45px] rounded-full border border-white'}
-            ></a>
+        >
+          {!isLoading && <Rounded size="sm" alt="profileImg" src={data?.data.data.memberProfileUrl}/>}
+        </Link>
         </div>
     );
 }

--- a/src/components/Login/UseSetLogin.tsx
+++ b/src/components/Login/UseSetLogin.tsx
@@ -1,9 +1,11 @@
 import { useEffect } from 'react';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { useSetRecoilState } from 'recoil';
 import { isLogin } from '../../storage/Login/Login';
 import { User } from '../../types/Login';
 import { useNavigate } from 'react-router-dom';
+import { MemberBrief } from '../../types/member';
+import { useQuery } from 'react-query';
 
 interface Props {
   code: string | null;
@@ -13,31 +15,18 @@ interface Props {
 /** 리다이렉트로 페이지 이동 시 */
 export default function useSetLogin({ code, state }: Props) {
   const nav = useNavigate();
-  const setUser = useSetRecoilState(isLogin);
-  console.log(`CODE: ${code} STATE: ${state}`);
+  // const setUser = useSetRecoilState(isLogin)
+  useQuery('login', () => request(), {
+    onSuccess: () => nav('/'),
+  });
 
   const request = async () => {
-    try {
-      const { data } = await axios.get(
-        `/oauth/login?code=${code}&state=${state}&redirectUri=${process.env.REACT_APP_OAUTH_REDIRECT_URI}/google/callback`,
-        {
-          withCredentials: true,
-        }
-      );
-      const { id, name, profile }: User = data;
-      setUser((prev) => ({
-        ...prev,
-        id,
-        name,
-        profile,
-      }));
-    } catch (err) {
-      alert('로그인에 실패했습니다.');
-    } finally {
-      nav('/');
-    }
+    const { data } = await axios.get<MemberBrief>(
+      `/oauth/login?code=${code}&state=${state}&redirectUri=${process.env.REACT_APP_OAUTH_REDIRECT_URI}/google/callback`,
+      {
+        withCredentials: true,
+      }
+    );
+    return data;
   };
-  useEffect(() => {
-    request().then((r) => {});
-  }, []);
 }

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import useGetMember from '../hooks/useGetMember';
+import { Navigate, Outlet } from 'react-router-dom';
+
+interface PrivateRouteProps {
+  children?: JSX.Element;
+}
+
+function PrivateRoute({ children }: PrivateRouteProps) {
+  const { data, isLoading } = useGetMember();
+  //@ts-ignore
+  const user = data?.data.data;
+
+  if (!isLoading && !user) return <Navigate to="/access" />;
+  return <Outlet />;
+}
+
+export default PrivateRoute;

--- a/src/components/RoundedImage/RoundedImage.tsx
+++ b/src/components/RoundedImage/RoundedImage.tsx
@@ -3,10 +3,23 @@ import type { ImgHTMLAttributes } from 'react';
 
 type RoundedImageProps = ImgHTMLAttributes<HTMLImageElement> & {
   alt: string;
+  size?: 'sm' | 'rg';
 };
 
-function Rounded(props: RoundedImageProps) {
-  return <img className="rounded-full" {...props} />;
+function Rounded({ size = 'sm', ...props }: RoundedImageProps) {
+  if (size === 'rg')
+    return (
+      <img
+        className="rounded-full object-cover object-center w-[150px] h-[150px]"
+        {...props}
+      />
+    );
+  return (
+    <img
+      className="rounded-full object-cover object-center w-[45px] h-[45px]"
+      {...props}
+    />
+  );
 }
 
 export default Rounded;

--- a/src/hooks/useGetMember.ts
+++ b/src/hooks/useGetMember.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useQuery } from 'react-query';
+import { getMemberDetailInfo } from '../apis/authApi';
+import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+function useGetMember() {
+  const navigate = useNavigate();
+  return useQuery('user', getMemberDetailInfo, {
+    staleTime: Infinity,
+    cacheTime: Infinity,
+
+    onError: (e: AxiosError) => {
+      console.log(e);
+      if (e.status === 403) {
+        console.log('로그인 유효기간이 만료되었습니다. 다시 로그인해주세요');
+        navigate('/access');
+      }
+    },
+  });
+}
+
+export default useGetMember;

--- a/src/storage/Login/Login.tsx
+++ b/src/storage/Login/Login.tsx
@@ -1,11 +1,7 @@
 import { atom } from 'recoil';
 import { User } from '../../types/Login';
 
-export const isLogin = atom<User>({
+export const isLogin = atom({
   key: 'loginInfo',
-  default: {
-    id: null,
-    name: null,
-    profile: null,
-  },
+  default: {},
 });

--- a/src/types/Login.ts
+++ b/src/types/Login.ts
@@ -1,5 +1,3 @@
-export interface User{
-    id:number | null
-    name:string | null
-    profile:string | null
-}
+import { MemberBrief } from './member';
+
+export interface User extends MemberBrief {}


### PR DESCRIPTION
* 로그인이 필요한 페이지 권한 확인 후 권한 없으면 'access'페이지로 이동하게 했습니다.
* 로그인 정보를 react-query로 관리할 수 있도록 useGetMember 훅을 작성했습니다.
* 헤더부분에 유저 이미지가 뜨도록 하였습니다.
* 로그아웃 부분은 임시입니다. 로그아웃 UI따로 만들고 로그아웃 버튼 핸들러에 아래 요청만 추가해주면 됩니다.
``` 
logoffRequest().then(() => {
          queryClient.resetQueries('user');
          navigate('/access');
        })
```

close #27 